### PR TITLE
Fix attribute name in MDITA topic example

### DIFF
--- a/CommitteeNote1/crossformat/crossformat-mdita.dita
+++ b/CommitteeNote1/crossformat/crossformat-mdita.dita
@@ -19,7 +19,7 @@ Network light bulbs from your <b>[product-name]</b> work with your light fixture
    
 &lt;p id="power-off">Make sure power to the fixture where you are installing the light bulb is turned OFF.&lt;/p>
    
-<b>&lt;p conref="low-power.html#low-power/disconnect-warning">&lt;/p></b>
+<b>&lt;p data-conref="low-power.html#low-power/disconnect-warning">&lt;/p></b>
 </codeblock>
  </conbody>
 </concept>


### PR DESCRIPTION
MDITA extended profile topics should use the `@data-conref` attribute for DITA content references.

_(I realize the preferred method for [Providing Feedback](https://www.oasis-open.org/committees/comments/index.php?wg_abbrev=dita) is by sending comments to the mailing list at dita-comment@lists.oasis-open.org, but the server did not respond to my subscription request.)_