### PR TITLE
Remove duplicate catalog entries

### DIFF
--- a/org.oasis-open.xdita/catalog-dita.xml
+++ b/org.oasis-open.xdita/catalog-dita.xml
@@ -20,12 +20,6 @@
 
   <!-- <public publicId="-//OASIS//ELEMENTS XDITA Highlight Domain//EN" uri="dtd/highlightDomain.mod"/> -->
 
-<public publicId="-//OASIS//DTD XDITA Topic//EN" uri="dtd/lw-topic.dtd"/>
-  <public publicId="-//OASIS//DTD XDITA Map//EN" uri="dtd/lw-map.dtd"/>
-
-  <public publicId="-//OASIS//ELEMENTS XDITA Topic//EN" uri="dtd/lw-topic.mod"/>
-  <public publicId="-//OASIS//ELEMENTS XDITA Map//EN" uri="dtd/lw-map.mod"/>
-
   <public publicId="-//OASIS//DTD LW DITA Topic//EN" uri="dtd/lw-topic.dtd"/>
   <public publicId="-//OASIS//DTD LW DITA Map//EN" uri="dtd/lw-map.dtd"/>
 


### PR DESCRIPTION
Apart from the indentation error, [lines 23–27](https://github.com/oasis-tcs/dita-lwdita/blob/master/org.oasis-open.xdita/catalog-dita.xml#L23-L27) are identical to [lines 15–19](https://github.com/oasis-tcs/dita-lwdita/blob/master/org.oasis-open.xdita/catalog-dita.xml#L15-L19).

Signed-off-by: Roger Sheen <roger@infotexture.net>