### PR TITLE
Rework introduction map

### DIFF
--- a/Spec/introduction/about-the-lightweight-dita-specification.dita
+++ b/Spec/introduction/about-the-lightweight-dita-specification.dita
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="about-the-lightweight-dita-specification">
+    <title>About the Lightweight DITA specification</title>
+    <shortdesc>The Lightweight DITA specification includes grammar files and the written
+        specification.</shortdesc>
+</concept>

--- a/Spec/introduction/introduction-lwdita-spec.dita
+++ b/Spec/introduction/introduction-lwdita-spec.dita
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="introduction-lwdita-spec">
+    <title>Introduction</title>
+    <shortdesc>The Lightweight DITA specification defines ...</shortdesc>
+</concept>

--- a/Spec/introduction/lw-introduction.ditamap
+++ b/Spec/introduction/lw-introduction.ditamap
@@ -2,7 +2,7 @@
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
 <map id="introduction">
     <title>Introduction</title>
-    <topicref href="../commonspec/specification/introduction/introduction-lwdita-spec.dita">
+    <topicref href="introduction-lwdita-spec.dita">
         <topicref href="about-the-lightweight-dita-specification.dita"/>
         <topicref href="../commonspec/specification/introduction/terminology.dita"/>
         <topicref href="../commonspec/specification/introduction/ipr-policy.dita"/>

--- a/Spec/introduction/lw-introduction.ditamap
+++ b/Spec/introduction/lw-introduction.ditamap
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
-<map id="map_mrd_qc2_rfb">
-    <topichead>
-        <topicmeta>
-            <navtitle>Introduction</navtitle>
-        </topicmeta>
-<!--        <topicref href="introduction.dita"/>-->
+<map id="introduction">
+    <title>Introduction</title>
+    <topicref href="../commonspec/specification/introduction/introduction-lwdita-spec.dita">
+        <topicref href="about-the-lightweight-dita-specification.dita"/>
+        <topicref href="../commonspec/specification/introduction/terminology.dita"/>
+        <topicref href="../commonspec/specification/introduction/ipr-policy.dita"/>
         <topicref href="normative-references.dita"/>
         <topicref href="non-normative-references(needs%20work).dita"/>
-        <topicref href="terminology.dita"/>
-    </topichead>
+        <topicref
+            href="../commonspec/specification/introduction/formatting-conventions-xhtml-output.dita">
+            <topicref href="../commonspec/specification/introduction/link-previews.dita"/>
+            <topicref href="../commonspec/specification/introduction/navigation-links.dita"/>
+        </topicref>
+    </topicref>
 </map>

--- a/Spec/introduction/non-normative-references(needs work).dita
+++ b/Spec/introduction/non-normative-references(needs work).dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="non-normative-references">
- <title>References</title>
+ <title>Non-normative references</title>
  <shortdesc>The following are references to external documents or resources that readers of this
   document might find useful.</shortdesc>
  <conbody>


### PR DESCRIPTION
Reworked introduction map to include required content:
- Added new "Introduction" topic
- Added new "About the Lightweight DITA specification" topic
- Referenced "Terminology," "IPR policy," and "Formatting conventions in the XHTML version of the specification" topics from the DITA 2.0 spec submodule
