### PR TITLE
Remove extra entry from components map

### DIFF
--- a/Spec/components/lw-components.ditamap
+++ b/Spec/components/lw-components.ditamap
@@ -30,7 +30,6 @@
    <topicref href="lw-pre.dita"/>
    <topicref href="lw-section.dita"/>
    <topicref href="lw-ul.dita"/>
-   <topicref href="lw-section.dita"/>
    <topicref href="lw-xref.dita"/>
   </topicref>
   <topicref href="containers/highlighting-components.dita">


### PR DESCRIPTION
`lw-section.dita` is in the map twice, which is not intended (and causes problems with chapter numbering).