### PR TITLE
Correct conkeyref

### DIFF
--- a/Spec/components/lw-keytext.dita
+++ b/Spec/components/lw-keytext.dita
@@ -31,7 +31,7 @@
         </dlentry>
       </dl>
     </section>
-    <section conkeyref="reuse-linktext/attributes"/>
+    <section conkeyref="reuse-keytext/attributes"/>
     <example>
       <title>Examples</title>
       <fig>


### PR DESCRIPTION
Correct conkeyref which still referenced the linktext topic