### PR TITLE
Remove obsolete domain values

### DIFF
--- a/org.oasis.xdita/dtd/lw-map.dtd
+++ b/org.oasis.xdita/dtd/lw-map.dtd
@@ -62,7 +62,7 @@ PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Map//EN"
 <!--                    DECLARE USE OF ELEMENT/ATTRIBUTE DOMAINS                 -->
 <!-- ============================================================= -->
 
-<!ENTITY included-domains               "(topic hi-d)(topic emph-d)(map mapgroup-d)">
+<!ENTITY included-domains               ""                           >
 
 <!-- ============================================================= -->
 <!--                    REMOVE ATTRIBUTE/ELEMENT GROUPS                    -->

--- a/org.oasis.xdita/dtd/lw-topic.dtd
+++ b/org.oasis.xdita/dtd/lw-topic.dtd
@@ -62,7 +62,7 @@ PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN"
 <!--                    DECLARE USE OF ELEMENT/ATTRIBUTE DOMAINS                 -->
 <!-- ============================================================= -->
 
-<!ENTITY included-domains                         "(topic hi-d)(topic em-d)"           >
+<!ENTITY included-domains                         ""                 >
 
 <!-- ============================================================= -->
 <!--                    REMOVE ATTRIBUTE/ELEMENT GROUPS                    -->


### PR DESCRIPTION
With the move from `@domains` to `@specializations` in DITA 2.0, the old domain tokens are no longer needed - the new attribute only includes attribute domain entries. The DTD has already been updated to rename the attribute, but we need to remove the obsolete tokens.