### PR TITLE
Updates to LwDITA grammar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ org.oasis.xdita/.DS_Store
 org.oasis.xdita/.DS_Store
 org.oasis.xdita/samples/.DS_Store
 org.oasis.xdita/.DS_Store
+out/
+temp/

--- a/org.oasis.xdita/dtd/lw-common.ent
+++ b/org.oasis.xdita/dtd/lw-common.ent
@@ -5,20 +5,24 @@
 <!--  VERSION:   1.0                                               -->
 <!--  DATE:      XXX                                               -->
 <!--                                                               -->
-<!--    26 Oct 2021  ES: split common entites element to their     -->
+<!--    26 Oct 2021  ES: split common entities element to their    -->
 <!--                     own files                                 -->
 <!--    04 Oct 2022 KJE: Removed entities that only contained a    -->
 <!--                     single attribute: control-variables,      -->
 <!--                     variable-content, and variable-links      -->
+<!--    15 Dec 2022 KJE: Added the inline.noimage entity,          -->
+<!--                     which is used for highlight and emphasis  -->
+<!--                     domain elements; changed "all-inline" to  -->
+<!--                     "inline" in entity names                  -->
 <!-- ============================================================= -->
 
 <!ENTITY % ph    "ph">
 <!ENTITY % data  "data">
 <!ENTITY % filter-adds " ">
 
-<!ENTITY % common-inline  "#PCDATA|%ph;|image|%data;">
-<!ENTITY % all-inline  "#PCDATA|%ph;|image|xref|%data;">
-
+<!ENTITY % inline           "#PCDATA|%ph;|image|xref|%data;">
+<!ENTITY % inline.noimage   "#PCDATA|%ph;|xref|%data;">
+<!ENTITY % inline.noxref    "#PCDATA|%ph;|image|%data;">
 
 <!ENTITY % filters
             'props      CDATA                              #IMPLIED

--- a/org.oasis.xdita/dtd/lw-common.mod
+++ b/org.oasis.xdita/dtd/lw-common.mod
@@ -43,7 +43,7 @@
                 class CDATA "- topic/data ">
 
 <!--                    LONG NAME: Phrase content  -->
-<!ELEMENT ph             (%all-inline;)*        >
+<!ELEMENT ph             (%inline;)*        >
 <!ATTLIST ph
                 %filters;
                 %localization;
@@ -52,7 +52,7 @@
                 class CDATA "- topic/ph ">
                 
 <!--                    LONG NAME: Reference  -->
-<!ELEMENT xref          (%common-inline;)*        >
+<!ELEMENT xref          (%inline.noxref;)*        >
 <!ATTLIST xref
              %filters;
              %localization;

--- a/org.oasis.xdita/dtd/lw-emphasisDomain.mod
+++ b/org.oasis.xdita/dtd/lw-emphasisDomain.mod
@@ -1,7 +1,7 @@
 <!-- ============================================================= -->
 <!--                    HEADER                                     -->
 <!-- ============================================================= -->
-<!--  MODULE:    Lightweight DITA Emphasis Domain              -->
+<!--  MODULE:    Lightweight DITA Emphasis Domain                  -->
 <!--  VERSION:   1.0                                               -->
 <!--  DATE:      XXX                                               -->
 <!--                                                               -->
@@ -34,10 +34,12 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Emphasis Domain//EN"
 <!--                     GitHub                                    -->
 <!--    04 Oct 2022 KJE: Defined @keyref directly on elements,     -->
 <!--                     replacing control-variables entity        -->
+<!--    15 Dec 2022 KJE: Changed the element content model to the  -->
+<!--                     inline.noimage entity                     -->
 <!-- ============================================================= -->
 
 <!--                    LONG NAME: Emphasized text  -->
-<!ELEMENT em             (%all-inline;)*        >
+<!ELEMENT em             (%inline.noimage;)*        >
 <!ATTLIST em
              %localization;
              keyref       CDATA          #IMPLIED
@@ -47,7 +49,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Emphasis Domain//EN"
              
                           
 <!--                    LONG NAME: Strong text  -->
-<!ELEMENT strong             (%all-inline;)*        >
+<!ELEMENT strong             (%inline.noimage;)*        >
 <!ATTLIST strong
                 %localization;
                 keyref       CDATA          #IMPLIED

--- a/org.oasis.xdita/dtd/lw-highlightDomain.mod
+++ b/org.oasis.xdita/dtd/lw-highlightDomain.mod
@@ -39,10 +39,13 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Highlight Domain//EN"
 <!--    14 Jul 2019 KJE: Alphabeticized element declarations       -->
 <!--    04 Oct 2022 KJE: Defined @keyref directly on elements,     -->
 <!--                     replacing control-variables entity        -->
+<!--    15 Dec 2022 KJE: Changed the element content model to the  -->
+<!--                     inline.noimage entity; added <tt>         -->
+<!--                     element                                   -->
 <!-- ============================================================= -->
 
 <!--                    LONG NAME: Bold content  -->
-<!ELEMENT b             (%all-inline;)*        >
+<!ELEMENT b             (%inline.noimage;)*        >
 <!ATTLIST b
              %localization;
              keyref       CDATA          #IMPLIED
@@ -51,7 +54,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Highlight Domain//EN"
 
 
 <!--                    LONG NAME: Italic content  -->
-<!ELEMENT i             (%all-inline;)*        >
+<!ELEMENT i             (%inline.noimage;)*        >
 <!ATTLIST i
              %localization;
              keyref       CDATA          #IMPLIED
@@ -60,7 +63,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Highlight Domain//EN"
              
              
 <!--                    LONG NAME: Subscript content  -->
-<!ELEMENT sub             (%all-inline;)*        >
+<!ELEMENT sub             (%inline.noimage;)*        >
 <!ATTLIST sub
              %localization;
              keyref       CDATA          #IMPLIED
@@ -68,15 +71,23 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Highlight Domain//EN"
              class CDATA "+ topic/ph hi-d/sub ">             
              
 <!--                    LONG NAME: Superscript content  -->
-<!ELEMENT sup             (%all-inline;)*        >
+<!ELEMENT sup             (%inline.noimage;)*         >
 <!ATTLIST sup
              %localization;
              keyref       CDATA          #IMPLIED
              outputclass  CDATA          #IMPLIED
-             class CDATA "+ topic/ph hi-d/sup ">             
+             class CDATA "+ topic/ph hi-d/sup ">   
+             
+<!--                    LONG NAME: Teletype content  -->
+<!ELEMENT tt             (%inline.noimage;)*          >
+<!ATTLIST tt
+             %localization;
+             keyref       CDATA          #IMPLIED
+             outputclass  CDATA          #IMPLIED
+             class CDATA "+ topic/ph hi-d/tt ">             
 
 <!--                    LONG NAME: Underlined content  -->
-<!ELEMENT u             (%all-inline;)*        >
+<!ELEMENT u             (%inline.noimage;)*          >
 <!ATTLIST u
              %localization;
              keyref       CDATA          #IMPLIED

--- a/org.oasis.xdita/dtd/lw-map.dtd
+++ b/org.oasis.xdita/dtd/lw-map.dtd
@@ -36,17 +36,18 @@ PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Map//EN"
 <!--    20 Jun 2017  CE: Added prefix lw- to filename              -->
 <!--    25 Jul 2017  CE: Changed public identifier to LIGHTWEIGHT  -->
 <!--                     DITA                                      -->
-<!--    08 Jun 2021  CE: Added Emphasis domain                     -->
-<!--    26 Oct 2021  ES: split common entites element to their     -->
+<!--    08 Jun 2021  CE: Added emphasis domain                     -->
+<!--    26 Oct 2021  ES: split common entities element to their    -->
 <!--                     own files                                 -->
+<!--    15 Dec 2022 KJE: Added <tt> as specialization of <ph>      -->
 <!-- ============================================================= -->
 
 <!-- ============================================================= -->
 <!--                    ADD PHRASE ELEMENTS                        -->
 <!-- ============================================================= -->
 
-<!-- hi-d -->
-<!ENTITY % ph           "ph | b | i |u | sup | sub | em | strong"       >
+<!-- hi-d and emphasis-d -->
+<!ENTITY % ph           "b | em | i | ph | strong | sub | sup | tt | u"       >
 
 
 <!-- ============================================================= -->

--- a/org.oasis.xdita/dtd/lw-map.mod
+++ b/org.oasis.xdita/dtd/lw-map.mod
@@ -70,9 +70,6 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Map//EN"
 <!--                    COMMON DECLARATIONS                       -->
 <!-- ============================================================= -->
 
-<!ENTITY % common-inline  "#PCDATA|%ph;|image|%data;">
-<!ENTITY % all-inline  "#PCDATA|%ph;|image|xref|%data;">
-
 <!--common attributes-->
 <!ENTITY  % processing-role
             'processing-role (normal | resource-only)      #IMPLIED'>

--- a/org.oasis.xdita/dtd/lw-topic.dtd
+++ b/org.oasis.xdita/dtd/lw-topic.dtd
@@ -35,9 +35,10 @@ PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN"
 <!--    20 Jun 2017  CE: Added prefix lw- to filename              -->
 <!--    25 Jul 2017  CE: Changed public identifier to LIGHTWEIGHT  -->
 <!--                     DITA                                      -->
-<!--    08 Jun 2021  CE: Added Emphasis domain                     -->
-<!--    26 Oct 2021  ES: split common entites element to their     -->
+<!--    08 Jun 2021  CE: Added emphasis domain                     -->
+<!--    26 Oct 2021  ES: split common entities element to their    -->
 <!--                     own files                                 -->
+<!--    15 Dec 2022 KJE: Added <tt> as specialization of <ph>      -->
 <!-- ============================================================= -->
 
 
@@ -45,8 +46,8 @@ PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN"
 <!--                    ADD PHRASE ELEMENTS                        -->
 <!-- ============================================================= -->
 
-<!-- hi-d -->
-<!ENTITY % ph           "b | em | i | ph | strong | sub | sup | u"       >
+<!-- hi-d and emphasis-d -->
+<!ENTITY % ph           "b | em | i | ph | strong | sub | sup | tt | u"       >
 
 
 <!-- ============================================================= -->

--- a/org.oasis.xdita/dtd/lw-topic.mod
+++ b/org.oasis.xdita/dtd/lw-topic.mod
@@ -144,7 +144,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Topic//EN"
              class CDATA "- topic/dd ">
 
 <!--                    LONG NAME: Description  -->
-<!ELEMENT desc		(%common-inline;)*        >
+<!ELEMENT desc		(%inline.noxref;)*        >
 <!ATTLIST desc
              %localization;
              %filters;
@@ -171,7 +171,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Topic//EN"
              class CDATA "- topic/dlentry ">
 
 <!--                    LONG NAME: Description term  -->
-<!ELEMENT dt             (%all-inline;)*        >
+<!ELEMENT dt             (%inline;)*        >
 <!ATTLIST dt
              %localization;
              %filters;
@@ -251,7 +251,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Topic//EN"
 
 
 <!--                    LONG NAME: Paragraph  -->
-<!ELEMENT p             (%all-inline;)*        >
+<!ELEMENT p             (%inline;)*        >
 <!ATTLIST p
              %localization;
              %filters;
@@ -287,7 +287,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Topic//EN"
              class CDATA "- topic/section ">
 
 <!--                    LONG NAME: Short description-->
-<!ELEMENT shortdesc     (%all-inline;)* >
+<!ELEMENT shortdesc     (%inline;)* >
 <!ATTLIST shortdesc
              %localization;
              %filters;
@@ -336,7 +336,7 @@ PUBLIC "-//OASIS//ELEMENTS LIGHTWEIGHT DITA Topic//EN"
              class CDATA "- topic/strow ">
 
 <!--                    LONG NAME: Title -->
-<!ELEMENT title (%common-inline;)* >
+<!ELEMENT title (%inline.noxref;)* >
 <!ATTLIST title
              %localization;
              outputclass  CDATA          #IMPLIED


### PR DESCRIPTION
 - Corrected content model for highight and emphasis domains
 - Added <tt> element to highlight domain
 - Added <tt> as extension of <ph> in document-type shells
 - Simplified names for "inline" entities and applied them in .mod files
 - Removed duplicate declarations for the inline entities