### PR TITLE
Remove obsolete values from catalog

### DIFF
--- a/org.oasis.xdita/catalog-dita.xml
+++ b/org.oasis.xdita/catalog-dita.xml
@@ -15,31 +15,4 @@
   <public publicId="-//OASIS//ELEMENTS LIGHTWEIGHT DITA Emphasis Domain//EN" uri="dtd/lw-emphasisDomain.mod"/>
 
 
-  <!-- The following values are deprecated, kept only for compatibility with the previous version -->
-  
-
-  <public publicId="-//OASIS//DTD XDITA Topic//EN" uri="dtd/lw-topic.dtd"/>
-  <public publicId="-//OASIS//DTD XDITA Map//EN" uri="dtd/lw-map.dtd"/>
-
-  <public publicId="-//OASIS//ELEMENTS XDITA Topic//EN" uri="dtd/lw-topic.mod"/>
-  <public publicId="-//OASIS//ELEMENTS XDITA Map//EN" uri="dtd/lw-map.mod"/>
-
-  <public publicId="-//OASIS//ELEMENTS XDITA Highlight Domain//EN" uri="dtd/highlightDomain.mod"/>
-
-  <public publicId="-//OASIS//DTD XDITA Topic//EN" uri="dtd/lw-topic.dtd"/>
-  <public publicId="-//OASIS//DTD XDITA Map//EN" uri="dtd/lw-map.dtd"/>
-
-  <public publicId="-//OASIS//ELEMENTS XDITA Topic//EN" uri="dtd/lw-topic.mod"/>
-  <public publicId="-//OASIS//ELEMENTS XDITA Map//EN" uri="dtd/lw-map.mod"/>
-  <public publicId="-//OASIS//ELEMENTS XDITA Common//EN" uri="dtd/lw-common.mod"/>
-  <public publicId="-//OASIS//ENTITIES XDITA Common//EN" uri="dtd/lw-common.ent"/>
-
-  <public publicId="-//OASIS//DTD LW DITA Topic//EN" uri="dtd/lw-topic.dtd"/>
-  <public publicId="-//OASIS//DTD LW DITA Map//EN" uri="dtd/lw-map.dtd"/>
-
-  <public publicId="-//OASIS//ELEMENTS LW DITA Topic//EN" uri="dtd/lw-topic.mod"/>
-  <public publicId="-//OASIS//ELEMENTS LW DITA Map//EN" uri="dtd/lw-map.mod"/>
-
-  <public publicId="-//OASIS//ELEMENTS LW DITA Highlight Domain//EN" uri="dtd/lw-highlightDomain.mod"/>
-
 </catalog>


### PR DESCRIPTION
Originally prompted by https://github.com/dita-ot/dita-ot/issues/4233

The XML catalog lists files that are not part of the repository and should be removed. Keeping the old values does not make sense -- if the new catalog and DTDs are used with files that have the old public IDs, many will not parse because of incompatible changes in the grammar. Topics using the old public ID should be using an older catalog that goes with the older grammar files.